### PR TITLE
Convert static HTML to WordPress plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# av-strategy-maker
-This aInteractive bankroll simulation WordPress plugin with dark UI. Visualizes betting strategies (fixed, martingale, dynamic, guarded martingale) using preloaded multipliers. Features real-time Chart.js graphs, controls for speed, cashout, reset, and toggles. Embed via shortcode for posts or pages.
+# Strategy Maker
+
+WordPress plugin displaying a bankroll simulation with a dark UI. It visualizes several betting strategies (fixed, martingale,
+dynamic, guarded martingale) using preloaded multipliers. The interface includes controls for speed, window size, cashout and a
+reset button, while dataset visibility can be toggled via the chart legend. Embed the UI in posts or pages using the
+`[strategy_maker]` shortcode.

--- a/strategy-maker.css
+++ b/strategy-maker.css
@@ -1,3 +1,7 @@
 .card { transition: transform .2s ease, box-shadow .2s ease; }
 .card:hover { transform: translateY(-2px); box-shadow: 0 10px 30px rgba(0,0,0,.25); }
 .mono { font-variant-numeric: tabular-nums; }
+
+#lqd-site-content {
+  background-color: #020617; /* slate-950 */
+}

--- a/strategy-maker.css
+++ b/strategy-maker.css
@@ -1,0 +1,3 @@
+.card { transition: transform .2s ease, box-shadow .2s ease; }
+.card:hover { transform: translateY(-2px); box-shadow: 0 10px 30px rgba(0,0,0,.25); }
+.mono { font-variant-numeric: tabular-nums; }

--- a/strategy-maker.js
+++ b/strategy-maker.js
@@ -1,121 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <title>Bankroll Simulation • Dark • Preloaded • Guarded Martingale</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <!-- Tailwind (CDN) -->
-  <script src="https://cdn.tailwindcss.com"></script>
-  <!-- Chart.js (CDN) -->
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"></script>
-  <style>
-    .card { transition: transform .2s ease, box-shadow .2s ease; }
-    .card:hover { transform: translateY(-2px); box-shadow: 0 10px 30px rgba(0,0,0,.25); }
-    .mono { font-variant-numeric: tabular-nums; }
-  </style>
-</head>
-<body class="min-h-screen bg-slate-950 text-slate-100 antialiased">
-  <main class="max-w-[1500px] mx-auto px-4 py-10">
-    <header class="mb-6">
-      <h1 class="text-3xl font-semibold tracking-tight">Bankroll Simulation (Dark • Preloaded)</h1>
-      <p class="text-slate-400 mt-1">
-        Bets only when <span class="font-semibold">previous &gt; 1.6</span>. Stream runs <span class="font-semibold">1.5× slower</span>.
-      </p>
-    </header>
+document.addEventListener('DOMContentLoaded', () => {
+  const siteBody = document.getElementById('lqd-site-content') || document.body;
+  siteBody.classList.add('min-h-screen', 'bg-slate-950', 'text-slate-100', 'antialiased');
 
-    <section class="card rounded-2xl bg-slate-900/70 ring-1 ring-slate-800 p-5 md:p-6">
-      <!-- Toolbar -->
-      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-4">
-        <div class="flex items-center gap-3">
-          <button id="btnToggle" class="px-4 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-500 active:scale-[.98] font-medium">
-            Pause
-          </button>
-
-          <div class="flex items-center gap-2">
-            <label for="speed" class="text-sm text-slate-300">Speed</label>
-            <input id="speed" type="range" min="50" max="1200" step="50"
-                   class="w-40 accent-indigo-500" value="250" />
-            <span class="text-xs text-slate-400">(effective ×1.5 slower)</span>
-          </div>
-
-          <div class="flex items-center gap-2">
-            <label for="window" class="text-sm text-slate-300">Window</label>
-            <select id="window" class="bg-slate-800/80 border border-slate-700 rounded-lg px-3 py-2 text-sm">
-              <option value="60">Last 60 pts</option>
-              <option value="120" selected>Last 120 pts</option>
-              <option value="240">Last 240 pts</option>
-            </select>
-          </div>
-        </div>
-
-        <div class="flex flex-wrap items-center gap-3">
-          <label class="inline-flex items-center gap-2 text-sm">
-            <input id="smooth" type="checkbox" class="size-4 accent-indigo-500" checked />
-            Smooth line
-          </label>
-
-          <label class="inline-flex items-center gap-2 text-sm">
-            <input id="seriesM" type="checkbox" class="size-4 accent-indigo-500" checked />
-            Show “With M - LM”
-          </label>
-
-          <label class="inline-flex items-center gap-2 text-sm">
-            <input id="series3" type="checkbox" class="size-4 accent-indigo-500" checked />
-            Show “No M - LM (Curr %)”
-          </label>
-
-          <label class="inline-flex items-center gap-2 text-sm">
-            <input id="seriesGuard" type="checkbox" class="size-4 accent-indigo-500" checked />
-            Show “With M - LM (Guard)”
-          </label>
-
-          <!-- Cashout input (default 3.7) -->
-          <div class="flex items-center gap-2">
-            <label for="cashout" class="text-sm text-slate-300">Cashout</label>
-            <input id="cashout" type="number" step="0.01" min="1.01" value="3.70"
-                   class="w-24 bg-slate-800/80 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-100" />
-          </div>
-
-          <button id="btnReset" class="px-3 py-2 rounded-lg bg-slate-800 hover:bg-slate-700 text-sm border border-slate-700">
-            Reset
-          </button>
-        </div>
-      </div>
-
-      <!-- Multipliers (left → right) -->
-      <div class="mb-4">
-        <h2 class="text-sm font-medium text-slate-300 mb-2">Last 10 multipliers</h2>
-        <div id="multis" class="flex flex-wrap gap-2 justify-start" style="direction:ltr"></div>
-        <div id="status" class="mt-2 text-xs text-slate-400"></div>
-      </div>
-
-      <!-- Chart -->
-      <div class="relative h-[420px] md:h-[480px]">
-        <canvas id="chart"></canvas>
-      </div>
-
-      <div class="mt-4 grid grid-cols-1 lg:grid-cols-4 gap-3 text-sm">
-        <div class="flex items-center gap-2">
-          <span class="inline-block size-3 rounded bg-indigo-500"></span>
-          <span class="text-slate-300">No M - LM: fixed bet (R75)</span>
-        </div>
-        <div class="flex items-center gap-2">
-          <span class="inline-block size-3 rounded bg-emerald-500"></span>
-          <span class="text-slate-300">With M - LM: martingale sequence</span>
-        </div>
-        <div class="flex items-center gap-2">
-          <span class="inline-block size-3 rounded bg-amber-500"></span>
-          <span class="text-slate-300">No M - LM (Curr %): 1.5% of current balance</span>
-        </div>
-        <div class="flex items-center gap-2">
-          <span class="inline-block size-3 rounded bg-rose-500"></span>
-          <span class="text-slate-300">With M - LM (Guard): martingale + stop &amp; resume rule</span>
-        </div>
-      </div>
-    </section>
-  </main>
-
-  <script>
     // -----------------------------
     // Preloaded multipliers (looping)
     // -----------------------------
@@ -467,10 +353,6 @@
     const btnReset    = document.getElementById('btnReset');
     const speedEl     = document.getElementById('speed');
     const windowEl    = document.getElementById('window');
-    const smoothEl    = document.getElementById('smooth');
-    const seriesMEl   = document.getElementById('seriesM');
-    const series3El   = document.getElementById('series3');
-    const seriesGuardEl = document.getElementById('seriesGuard');
 
     let running = true;
     let interval = null;
@@ -603,23 +485,6 @@
     });
     speedEl.addEventListener('input', () => { if (running) startLoop(); });
     windowEl.addEventListener('change', () => { clampWindow(); chart.update(); });
-    smoothEl.addEventListener('change', () => {
-      const t = smoothEl.checked ? 0.35 : 0;
-      chart.data.datasets.forEach(ds => ds.tension = t);
-      chart.update();
-    });
-    seriesMEl.addEventListener('change', () => {
-      chart.data.datasets[1].hidden = !seriesMEl.checked;
-      chart.update();
-    });
-    series3El.addEventListener('change', () => {
-      chart.data.datasets[2].hidden = !series3El.checked;
-      chart.update();
-    });
-    seriesGuardEl.addEventListener('change', () => {
-      chart.data.datasets[3].hidden = !seriesGuardEl.checked;
-      chart.update();
-    });
     cashoutEl.addEventListener('input', () => {
       const v = parseFloat(cashoutEl.value);
       if (!isNaN(v) && v > 1) cashout = v;
@@ -662,6 +527,4 @@
     });
 
     window.addEventListener('beforeunload', stopLoop);
-  </script>
-</body>
-</html>
+});

--- a/strategy-maker.php
+++ b/strategy-maker.php
@@ -1,0 +1,94 @@
+<?php
+/*
+Plugin Name: Strategy Maker
+Description: Display the bankroll simulation UI via shortcode [strategy_maker].
+Version: 1.0.0
+*/
+
+function strategy_maker_enqueue() {
+    wp_enqueue_script('tailwind', 'https://cdn.tailwindcss.com', [], null, false);
+    wp_enqueue_script('chartjs', 'https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js', [], null, true);
+    wp_enqueue_style('strategy-maker', plugins_url('strategy-maker.css', __FILE__), [], '1.0.0');
+    wp_enqueue_script('strategy-maker', plugins_url('strategy-maker.js', __FILE__), ['chartjs'], '1.0.0', true);
+}
+
+function strategy_maker_shortcode() {
+    strategy_maker_enqueue();
+    ob_start();
+    ?>
+    <div id="strategy-maker-root">
+      <main class="max-w-[1500px] mx-auto px-4 py-10">
+        <header class="mb-6">
+          <h1 class="text-3xl font-semibold tracking-tight">Bankroll Simulation (Dark • Preloaded)</h1>
+          <p class="text-slate-400 mt-1">
+            Bets only when <span class="font-semibold">previous &gt; 1.6</span>. Stream runs <span class="font-semibold">1.5× slower</span>.
+          </p>
+        </header>
+
+        <section class="card rounded-2xl bg-slate-900/70 ring-1 ring-slate-800 p-5 md:p-6">
+          <div class="flex flex-wrap items-center gap-3 mb-4">
+            <button id="btnToggle" class="px-4 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-500 active:scale-[.98] font-medium">
+              Pause
+            </button>
+
+            <div class="flex items-center gap-2">
+              <label for="speed" class="text-sm text-slate-300">Speed</label>
+              <input id="speed" type="range" min="50" max="1200" step="50" class="w-40 accent-indigo-500" value="250" />
+              <span class="text-xs text-slate-400">(effective ×1.5 slower)</span>
+            </div>
+
+            <div class="flex items-center gap-2">
+              <label for="window" class="text-sm text-slate-300">Window</label>
+              <select id="window" class="bg-slate-800/80 border border-slate-700 rounded-lg px-3 py-2 text-sm">
+                <option value="60">Last 60 pts</option>
+                <option value="120" selected>Last 120 pts</option>
+                <option value="240">Last 240 pts</option>
+              </select>
+            </div>
+
+            <div class="flex items-center gap-2">
+              <label for="cashout" class="text-sm text-slate-300">Cashout</label>
+              <input id="cashout" type="number" step="0.01" min="1.01" value="3.70"
+                     class="w-24 bg-slate-800/80 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-100" />
+            </div>
+
+            <button id="btnReset" class="px-3 py-2 rounded-lg bg-slate-800 hover:bg-slate-700 text-sm border border-slate-700">
+              Reset
+            </button>
+          </div>
+
+          <div class="mb-4">
+            <h2 class="text-sm font-medium text-slate-300 mb-2">Last 10 multipliers</h2>
+            <div id="multis" class="flex flex-wrap gap-2 justify-start" style="direction:ltr"></div>
+            <div id="status" class="mt-2 text-xs text-slate-400"></div>
+          </div>
+
+          <div class="relative h-[420px] md:h-[480px]">
+            <canvas id="chart"></canvas>
+          </div>
+
+          <div class="mt-4 grid grid-cols-1 lg:grid-cols-4 gap-3 text-sm">
+            <div class="flex items-center gap-2">
+              <span class="inline-block size-3 rounded bg-indigo-500"></span>
+              <span class="text-slate-300">No M - LM: fixed bet (R75)</span>
+            </div>
+            <div class="flex items-center gap-2">
+              <span class="inline-block size-3 rounded bg-emerald-500"></span>
+              <span class="text-slate-300">With M - LM: martingale sequence</span>
+            </div>
+            <div class="flex items-center gap-2">
+              <span class="inline-block size-3 rounded bg-amber-500"></span>
+              <span class="text-slate-300">No M - LM (Curr %): 1.5% of current balance</span>
+            </div>
+            <div class="flex items-center gap-2">
+              <span class="inline-block size-3 rounded bg-rose-500"></span>
+              <span class="text-slate-300">With M - LM (Guard): martingale + stop &amp; resume rule</span>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode('strategy_maker', 'strategy_maker_shortcode');


### PR DESCRIPTION
## Summary
- turn static simulation UI into a WordPress plugin with shortcode `[strategy_maker]`
- consolidate controls and remove dataset checkboxes and smooth-line toggle
- apply tailwind styling to `#lqd-site-content` and enable smooth chart lines by default

## Testing
- `php -l strategy-maker.php`
- `node --check strategy-maker.js`

------
https://chatgpt.com/codex/tasks/task_e_68c44710a7348321bfcdd6b1d2723fd9